### PR TITLE
Modify stop condition for cflmax in MPI section

### DIFF
--- a/src/solve2.F
+++ b/src/solve2.F
@@ -2079,9 +2079,11 @@
 #ifdef MPI
       ! finish comms for cflquick:
       call mpi_wait(reqc,mpi_status_ignore,ierr)
-      if(cflmax.ge.1.50) stopit=.true.
       if(timestats.ge.1) time_cflq=time_cflq+mytime()
 #endif
+
+if( cflmax.ge.1.50 .or. cflmax.ne.cflmax ) stopit=.true.
+! .ne. is because of nan test
 
 !--------------------------------------------------------------------
 


### PR DESCRIPTION
Updated condition to stop execution based on cflmax value. ARM gives nan values after t=3.77 but model do not realize it. The model run without the crash but large number of nan values. 