### PR TITLE
Fix delta-T calculation in sfcphys.F fixing potential temperature

### DIFF
--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -1100,7 +1100,7 @@
       endif
 
       ! save delta-T and delta-q (used for use_avg_sfc only)
-      delt = t1(i,j)/pisfc-tsk(i,j)
+      delt = t1(i,j)-tsk(i,j)/pisfc
       delq = q1(i,j)-qsfc(i,j)
 
     enddo

--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -1100,7 +1100,7 @@
       endif
 
       ! save delta-T and delta-q (used for use_avg_sfc only)
-      delt = t1(i,j)-tsk(i,j)
+      delt = t1(i,j)/pisfc-tsk(i,j)
       delq = q1(i,j)-qsfc(i,j)
 
     enddo


### PR DESCRIPTION
Correct delta-T calculation by dividing t1 by pisfc to convert it to surface temperature